### PR TITLE
Fix nav links and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically load the [Poppins](https://fonts.google.com/specimen/Poppins) and [Playball](https://fonts.google.com/specimen/Playball) fonts.
 
 ## Learn More
 

--- a/app/Components/Footer-Content.tsx
+++ b/app/Components/Footer-Content.tsx
@@ -6,7 +6,6 @@ function FooterContent() {
     { name: "About", href: "#about" },
     { name: "Leadership", href: "#leadership" },
     { name: "Ventures", href: "#ventures" },
-    { name: "Investments", href: "#investments" },
     { name: "Media", href: "#media" },
     { name: "Contact", href: "#contact" },
   ];

--- a/app/Components/Header.tsx
+++ b/app/Components/Header.tsx
@@ -9,7 +9,7 @@ const Header: React.FC = () => {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [activeItem, setActiveItem] = useState<string>("");
 
-  const navItems = ["About", "Leadership", "Ventures", "Investments", "Media"];
+  const navItems = ["About", "Leadership", "Ventures", "Media"];
 
   useEffect(() => {
     if (isSidebarOpen) {

--- a/app/Components/Industry.tsx
+++ b/app/Components/Industry.tsx
@@ -18,7 +18,7 @@ const Industry: React.FC = () => {
 
       {/* Text content */}
       <div className="absolute inset-0 flex flex-col items-center justify-center text-center text-white px-4 z-20">
-        <h1 className="text-poppins-bold text-heading-responsive text-[60px] font-bold sm:leading-nomal ">
+        <h1 className="text-poppins-bold text-heading-responsive text-[60px] font-bold sm:leading-normal ">
           Investing in <br /> Visionaries Reshaping Industries
         </h1>
         <div className="gap-[40px] flex flex-col items-center justify-center mt-4">


### PR DESCRIPTION
## Summary
- fix small typo in industry section heading
- remove non-existent "Investments" link from header and footer
- correct README about fonts used

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68423620bb14832bb103a146d21e3d99